### PR TITLE
Make mock prover lower latency for testing

### DIFF
--- a/test/config/test.prover.config.json
+++ b/test/config/test.prover.config.json
@@ -9,7 +9,7 @@
     "runAggregatorServer": false,
     "runAggregatorClient": false,
     "runAggregatorClientMock": true, 
-    "aggregatorClientMockTimeout": 15000000,
+    "aggregatorClientMockTimeout": 1000,
     
     "runFileGenBatchProof": false,
     "runFileGenAggregatedProof": false,


### PR DESCRIPTION
The mock prover has a timer to simulate latency of the real prover. The time is completely arbitrary since the mock prover is not doing any work itself. The setting is in us, so setting it to 1000 gives a small latency of 1ms.