### PR TITLE
Build and push docker on git tags

### DIFF
--- a/.github/workflows/espresso-push-docker.yml
+++ b/.github/workflows/espresso-push-docker.yml
@@ -6,6 +6,7 @@ on:
       - hotshot-integration
     tags:
       - 'v*'
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
I think this should give us tagged docker images if we tag a git release, that we can then refer to in the sequencer repo or for local testing.