### PR TITLE
Return error if query service responds with error

### DIFF
--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -545,7 +545,7 @@ func (etherMan *Client) decodeSequencesHotShot(ctx context.Context, txData []byt
 			return nil, err
 		}
 		if response.StatusCode != 200 {
-			return nil, err
+			return nil, fmt.Errorf("Query service responded with status code %d", response.StatusCode)
 		}
 
 		var hexStr string


### PR DESCRIPTION
Currently this is returning `nil, nil` which seems like a bad idea.