### PR TITLE
Configurable ethtxmanager monitoring interval

### DIFF
--- a/ethtxmanager/config.go
+++ b/ethtxmanager/config.go
@@ -12,4 +12,7 @@ type Config struct {
 	// PrivateKeys defines all the key store files that are going
 	// to be read in order to provide the private keys to sign the L1 txs
 	PrivateKeys []types.KeystoreFileConfig `mapstructure:"PrivateKeys"`
+
+	// How often to poll for transaction receipts when monitoring.
+	PollInterval types.Duration `mapstructure:"PollingInterval"`
 }

--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -601,7 +601,7 @@ func (c *Client) ProcessPendingMonitoredTxs(ctx context.Context, owner string, r
 			// if the result is either not confirmed or failed, it means we need to wait until it gets confirmed of failed.
 			for {
 				// wait before refreshing the result info
-				time.Sleep(time.Second)
+				time.Sleep(c.cfg.PollInterval.Duration)
 
 				// refresh the result info
 				result, err := c.Result(ctx, owner, result.ID, dbTx)

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -112,6 +112,7 @@ PrivateKeys = [
 	{Path = "/pk/sequencer.keystore", Password = "testonly"},
 	{Path = "/pk/aggregator.keystore", Password = "testonly"}
 ]
+PollInterval = "1s"
 
 [L2GasPriceSuggester]
 Type = "follower"


### PR DESCRIPTION
Tested that demo still runs but this code path doesn't get exercised on the default local demo.