### PR TITLE
Set zero timestamp for genesis batch

### DIFF
--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -532,7 +532,7 @@ func (etherMan *Client) newBlocksEvent(ctx context.Context, vLog types.Log, bloc
 	if err != nil {
 		return err
 	}
-	log.Debug("NewBlocks event detected %+v", newBlocks)
+	log.Debugf("NewBlocks event detected %+v", newBlocks)
 
 	// Read the tx for this event.
 	tx, isPending, err := etherMan.EthClient.TransactionByHash(ctx, vLog.TxHash)

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -99,7 +99,9 @@ func (s *ClientSynchronizer) Sync() error {
 				BlockNumber: header.Number.Uint64(),
 				BlockHash:   header.Hash(),
 				ParentHash:  header.ParentHash,
-				ReceivedAt:  time.Unix(int64(header.Time), 0),
+				// TODO: Setting this "zero" timestamp is a workaround
+				// See: https://github.com/EspressoSystems/espresso-sequencer/issues/631
+				ReceivedAt: time.Time{},
 			}
 			newRoot, err := s.state.SetGenesis(s.ctx, *lastEthBlockSynced, s.genesis, dbTx)
 			if err != nil {


### PR DESCRIPTION
This is a workaround to ensure the timestamp of batch 1 (which is determined by the L1 block referred in the HotShot block) is larger than the timestamp of the genesis batch (batch 0).

For more details see: https://github.com/EspressoSystems/espresso-sequencer/issues/631
