### PR TITLE
Use zero unix timestamp instead of zero timestamp

### DIFF
--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -101,7 +101,7 @@ func (s *ClientSynchronizer) Sync() error {
 				ParentHash:  header.ParentHash,
 				// TODO: Setting this "zero" timestamp is a workaround
 				// See: https://github.com/EspressoSystems/espresso-sequencer/issues/631
-				ReceivedAt: time.Time{},
+				ReceivedAt: time.Unix(0, 0),
 			}
 			newRoot, err := s.state.SetGenesis(s.ctx, *lastEthBlockSynced, s.genesis, dbTx)
 			if err != nil {


### PR DESCRIPTION
The zero timestamp breaks blockscout:

    [error] GenServer
    Indexer.Block.Catchup.MissingRangesCollector terminating
    ** (ArgumentError) invalid Unix time 18446744011573954816
